### PR TITLE
Adding a catch-all DHCP configuration

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -51,6 +51,15 @@ if [ -f /etc/udev/rules.d/70-persistent-net.rules ]; then
     sudo rm /etc/udev/rules.d/70-persistent-net.rules
 fi
 
+#add failsafe DHCP config for systemd-networkd
+if [ -d /etc/systemd/network ]; then
+    echo "[Match]
+Name=en*
+
+[Network]
+DHCP=ipv4" | sudo tee 99-dhcp-default.network
+fi
+
 #cleanup /tmp directories
 sudo rm -rf /tmp/*
 sudo rm -rf /var/tmp/*


### PR DESCRIPTION
It appears that for libvirt/kvm the interfaces are renumbered in such a way as they do not come up when booted by Vagrant. To fix that I have added a catch-all interface configuration in `/etc/systemd/network/`.