### PR TITLE
Update ISO metadata

### DIFF
--- a/openSUSE/leap-15.1/server/template.json
+++ b/openSUSE/leap-15.1/server/template.json
@@ -1,7 +1,7 @@
 {
   "boot_command_prefix": "",
-  "iso_checksum": "c50f47cf49c57656f9b8fe70d45b9ad7d99a15633c3e48af18407496f3c8f359",
+  "iso_checksum": "609d0ad527ab13681b44e28326cd7941e87adfe8d522e2b31d0d7c71e9d92992",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://download.opensuse.org/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64-Current.iso",
+  "iso_url": "https://download.opensuse.org/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso",
   "vm_name": "leap151-server-packer-template"
 }


### PR DESCRIPTION
There's no more "-current" iso and it has a new hash now, see https://download.opensuse.org/distribution/leap/15.1/iso/