### PR TITLE
Added Global Packer Cache Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 *.box
 *.iso
 output-*
-packer_cache
+packer_cache/*
+!packer_cache/.gitkeep
 private_vars.json
 Vagrantfile
 venv

--- a/Alpine/3.10/server/packer_cache
+++ b/Alpine/3.10/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Alpine/3.7/server/packer_cache
+++ b/Alpine/3.7/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Alpine/3.8/server/packer_cache
+++ b/Alpine/3.8/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Alpine/3.9/server/packer_cache
+++ b/Alpine/3.9/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Arch/2018.09.01/server/packer_cache
+++ b/Arch/2018.09.01/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Arch/2018.10.01/server/packer_cache
+++ b/Arch/2018.10.01/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Arch/2018.11.01/server/packer_cache
+++ b/Arch/2018.11.01/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Arch/2018.12.01/server/packer_cache
+++ b/Arch/2018.12.01/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Arch/2019.01.01/server/packer_cache
+++ b/Arch/2019.01.01/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Arch/2019.02.01/server/packer_cache
+++ b/Arch/2019.02.01/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Arch/2019.03.01/server/packer_cache
+++ b/Arch/2019.03.01/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Arch/latest/server/packer_cache
+++ b/Arch/latest/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/CentOS/5/server/packer_cache
+++ b/CentOS/5/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/CentOS/6/server/packer_cache
+++ b/CentOS/6/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/CentOS/7/desktop/packer_cache
+++ b/CentOS/7/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/CentOS/7/server/packer_cache
+++ b/CentOS/7/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/CentOS/8/desktop/packer_cache
+++ b/CentOS/8/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/CentOS/8/server/packer_cache
+++ b/CentOS/8/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Debian/buster64/desktop/packer_cache
+++ b/Debian/buster64/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Debian/buster64/server/packer_cache
+++ b/Debian/buster64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Debian/jessie64/server/packer_cache
+++ b/Debian/jessie64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Debian/stretch64/desktop/packer_cache
+++ b/Debian/stretch64/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Debian/stretch64/server/packer_cache
+++ b/Debian/stretch64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Debian/wheezy64/server/packer_cache
+++ b/Debian/wheezy64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/21/server/packer_cache
+++ b/Fedora/21/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/22/server/packer_cache
+++ b/Fedora/22/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/23/server/packer_cache
+++ b/Fedora/23/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/24/server/packer_cache
+++ b/Fedora/24/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/25/server/packer_cache
+++ b/Fedora/25/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/26/server/packer_cache
+++ b/Fedora/26/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/27/server/packer_cache
+++ b/Fedora/27/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/28/desktop/packer_cache
+++ b/Fedora/28/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/28/server/packer_cache
+++ b/Fedora/28/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/29/desktop/packer_cache
+++ b/Fedora/29/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/29/server/packer_cache
+++ b/Fedora/29/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/30/desktop/packer_cache
+++ b/Fedora/30/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/30/server/packer_cache
+++ b/Fedora/30/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/31/desktop/packer_cache
+++ b/Fedora/31/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Fedora/31/server/packer_cache
+++ b/Fedora/31/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/FreeNAS/11.2/server/packer_cache
+++ b/FreeNAS/11.2/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/LinuxMint/18/desktop/packer_cache
+++ b/LinuxMint/18/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/LinuxMint/19/desktop/packer_cache
+++ b/LinuxMint/19/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/NethServer/7/server/packer_cache
+++ b/NethServer/7/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Oracle-Linux/7/server/packer_cache
+++ b/Oracle-Linux/7/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Scientific-Linux/7/server/packer_cache
+++ b/Scientific-Linux/7/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Test/dummy/server/packer_cache
+++ b/Test/dummy/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/artful64/desktop/packer_cache
+++ b/Ubuntu/artful64/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/artful64/server/packer_cache
+++ b/Ubuntu/artful64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/bionic64/desktop/packer_cache
+++ b/Ubuntu/bionic64/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/bionic64/server/packer_cache
+++ b/Ubuntu/bionic64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/cosmic64/desktop/packer_cache
+++ b/Ubuntu/cosmic64/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/cosmic64/server/packer_cache
+++ b/Ubuntu/cosmic64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/dingo64/desktop/packer_cache
+++ b/Ubuntu/dingo64/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/dingo64/server/packer_cache
+++ b/Ubuntu/dingo64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/ermine64/desktop/packer_cache
+++ b/Ubuntu/ermine64/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/ermine64/server/packer_cache
+++ b/Ubuntu/ermine64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/precise64/server/packer_cache
+++ b/Ubuntu/precise64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/trusty64/desktop/packer_cache
+++ b/Ubuntu/trusty64/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/trusty64/server/packer_cache
+++ b/Ubuntu/trusty64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/utopic64/server/packer_cache
+++ b/Ubuntu/utopic64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/vivid64/server/packer_cache
+++ b/Ubuntu/vivid64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/wily64/server/packer_cache
+++ b/Ubuntu/wily64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/xenial64/desktop/packer_cache
+++ b/Ubuntu/xenial64/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/xenial64/server/packer_cache
+++ b/Ubuntu/xenial64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/yakkety64/server/packer_cache
+++ b/Ubuntu/yakkety64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/zesty64/desktop/packer_cache
+++ b/Ubuntu/zesty64/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Ubuntu/zesty64/server/packer_cache
+++ b/Ubuntu/zesty64/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/VyOS/1.1.8/networking/packer_cache
+++ b/VyOS/1.1.8/networking/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Windows/10/desktop/packer_cache
+++ b/Windows/10/desktop/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Windows/2008r2/server/packer_cache
+++ b/Windows/2008r2/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Windows/2012r2/server/packer_cache
+++ b/Windows/2012r2/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Windows/2016/server/packer_cache
+++ b/Windows/2016/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/Windows/2019/server/packer_cache
+++ b/Windows/2019/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/openSUSE/leap-15.0/server/packer_cache
+++ b/openSUSE/leap-15.0/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/openSUSE/leap-15.1/server/packer_cache
+++ b/openSUSE/leap-15.1/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/openSUSE/leap-42.2/server/packer_cache
+++ b/openSUSE/leap-42.2/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/openSUSE/leap-42.3/server/packer_cache
+++ b/openSUSE/leap-42.3/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/openSUSE/tumbleweed/server/packer_cache
+++ b/openSUSE/tumbleweed/server/packer_cache
@@ -1,0 +1,1 @@
+../../../packer_cache

--- a/utils.py
+++ b/utils.py
@@ -117,7 +117,7 @@ def prep_builds(repo, repo_facts, builds):
 
 
 def cleanup_linked_dirs(build_dir, repo, repo_facts):
-    linked_dirs = ['http', 'scripts']
+    linked_dirs = ['http', 'packer_cache', 'scripts']
 
     for linked_dir in linked_dirs:
         dir_path = os.path.join(build_dir, linked_dir)
@@ -359,8 +359,8 @@ def cleanup_builds():
                 shutil.rmtree(os.path.join(root, item))
             if item == '.vagrant':
                 shutil.rmtree(os.path.join(root, item))
-            if item == 'packer_cache':
-                shutil.rmtree(os.path.join(root, item))
+            # if item == 'packer_cache':
+            #     shutil.rmtree(os.path.join(root, item))
 
         for item in files:
             filename, ext = os.path.splitext(item)


### PR DESCRIPTION
- This adds a global packer_cache directory for all builds as a symlink
to the root directory of this project. The files within this folder are
added to .gitignore to ensure that they do not get committed.
- This gives us the ability to not need to pull down duplicate ISO's,
etc. which are used across like distros.
- Resolves https://github.com/mrlesmithjr/packer-templates/issues/35